### PR TITLE
Add SUSE default route

### DIFF
--- a/templates/user-data.write_files.sles
+++ b/templates/user-data.write_files.sles
@@ -17,6 +17,14 @@ write_files:
     NETWORK=''
     REMOTE_IPADDR=''
     STARTMODE='auto'
+  owner: 'root:root'
+  permissions: '0644'
+
+- path: /etc/sysconfig/network/ifroute-br-prd
+  content: |
+    default 10.1.0.1 - -
+  owner: 'root:root'
+  permissions: '0644'
 
 - path: /etc/sysconfig/network/ifcfg-eth0
   content: |
@@ -33,7 +41,7 @@ write_files:
     REMOTE_IPADDR=''
     STARTMODE='auto'
   owner: 'root:root'
-  permissions: '0644'    
+  permissions: '0644'
 
 - path: /etc/sysconfig/network/ifcfg-eth1
   content: |

--- a/templates/user-data.write_files.sles
+++ b/templates/user-data.write_files.sles
@@ -22,7 +22,7 @@ write_files:
 
 - path: /etc/sysconfig/network/ifroute-br-prd
   content: |
-    default 10.1.0.1 - -
+    default 10.VM_CID.0.1 - -
   owner: 'root:root'
   permissions: '0644'
 


### PR DESCRIPTION
Added a missing default route in the sles network configuration

The /templates/user-data.write_files.sles file has been edited.

The following distributions are affected by this adjustements:

- sles12
- sles15