### PR TITLE
Add sles registration

### DIFF
--- a/templates/user-data.run_cmd.sles
+++ b/templates/user-data.run_cmd.sles
@@ -1,8 +1,5 @@
 runcmd:
   - /usr/bin/localectl set-keymap fr
   - echo "AllowUsers opensvc" >> /etc/ssh/sshd_config
-  - restart ssh
-  - [rm, /boot/firmware/user-data]
-  - pvcreate -f /dev/vdb
-  - vgcreate datavg /dev/vdb
+  - [ sh, "/run/scripts/sles-register.sh" ]
   - [reboot]

--- a/templates/user-data.run_cmd.sles
+++ b/templates/user-data.run_cmd.sles
@@ -1,5 +1,7 @@
 runcmd:
   - /usr/bin/localectl set-keymap fr
   - echo "AllowUsers opensvc" >> /etc/ssh/sshd_config
+  - sed -i 's/NETCONFIG_DNS_STATIC_SERVERS=""/NETCONFIG_DNS_STATIC_SERVERS="10.VM_CID.0.1 10.VM_CID.1.1"/g' /etc/sysconfig/network/config
+  - systemctl restart network
   - [ sh, "/run/scripts/sles-register.sh" ]
   - [reboot]

--- a/templates/user-data.write_files.sles
+++ b/templates/user-data.write_files.sles
@@ -74,3 +74,18 @@ write_files:
     STARTMODE='auto'
   owner: "root:root"
   permissions: "0644"
+
+- path: /run/scripts/sles-register.sh
+  content: |
+    #!/bin/bash
+
+    SUSEConnect  -d
+    SUSEConnect --cleanup
+
+    SUSEConnect -r SUSE_REGISTRATION_KEY -e SUSE_ORGANISATION_MAIL
+
+    zypper refresh
+
+    exit 0
+  owner: "root:root"
+  permissions: "0750"

--- a/tools/kvm.provision.sh
+++ b/tools/kvm.provision.sh
@@ -100,6 +100,8 @@ function substitute_patterns()
     sed -i "s@VM_IP@$VM_IP@g" $FILES
     sed -i "s@RH_ORG_ID@$RH_ORG_ID@g" $FILES
     sed -i "s@RH_ACTIVATION_KEY@$RH_ACTIVATION_KEY@g" $FILES
+    sed -i "s/SUSE_ORGANISATION_MAIL/$SUSE_ORGANISATION_MAIL/g" $FILES
+    sed -i "s@SUSE_REGISTRATION_KEY@$SUSE_REGISTRATION_KEY@g" $FILES
     title End:$FUNCNAME
 }
 


### PR DESCRIPTION
Added the SUSE portal registration process and fixed the DNS static configuration issue with a sed command line in the /template/user-data.run_cmd.sles file.

The following distributions are concerned by these modifications:

- sles12
- sles15